### PR TITLE
Use HTTPS instead of SSH URL for minecraft-data submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "crates/generators/minecraft-data"]
 	path = crates/generators/minecraft-data
-	url = git@github.com:PrismarineJS/minecraft-data.git
+	url = https://github.com/PrismarineJS/minecraft-data


### PR DESCRIPTION
Using `libcraft` as a Git dependency in `quill` and Feather was causing authentication errors when downloading the submodule. This is a tentative fix.