### PR TITLE
Add remaining relative directions to BlockPosition

### DIFF
--- a/crates/core/src/positions.rs
+++ b/crates/core/src/positions.rs
@@ -318,6 +318,38 @@ impl BlockPosition {
             z: self.z,
         }
     }
+
+    pub fn north(self) -> BlockPosition {
+        Self {
+            x: self.x,
+            y: self.y,
+            z: self.z - 1,
+        }
+    }
+
+    pub fn south(self) -> BlockPosition {
+        Self {
+            x: self.x,
+            y: self.y,
+            z: self.z + 1,
+        }
+    }
+
+    pub fn east(self) -> BlockPosition {
+        Self {
+            x: self.x + 1,
+            y: self.y,
+            z: self.z,
+        }
+    }
+
+    pub fn west(self) -> BlockPosition {
+        Self {
+            x: self.x - 1,
+            y: self.y,
+            z: self.z,
+        }
+    }
 }
 
 impl Add<BlockPosition> for BlockPosition {


### PR DESCRIPTION
This pull request just adds functions for the remaining relative block directions for a BlockPosition (in addition to up and down):

- North (0, 0, -1)
- South (0, 0,  1)
- East ( 1, 0, 0)
- West (-1, 0, 0)

I have no idea why north is negative Z in Minecraft but here we are.